### PR TITLE
Add GitHub Skills activity to course catalog

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal during the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities catalog
- Schedule: Wednesdays, 3:30 PM - 5:00 PM
- Capacity: 25 students
- Includes description mentioning the GitHub Certifications program

## Closes
Fixes #6

## Context
Students like Hewbie C. were unable to find and register for this time-sensitive activity. Registration deadline is by the end of this week, so this needs to be deployed quickly.

## Testing
- ✅ No syntax errors
- ✅ Activity follows the same data structure as existing activities
- ✅ Ready for students to sign up